### PR TITLE
Adding "checkrepo" flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ The `cvmanager` tool can execute this task when called as `cvmanager clean`. By 
 
 Sometimes it can be beneficial to automatically update specific Content Views, for example the base OS Content View should be kept uptodate with the upstream OS repositories. To achieve that Katello/Satellite can schedule syncs of the repositories, but the synced content will not be available to the clients until the administrator publishes a new version of a Content View containing these repositories.
 
-`cvmanager` can be configured to automatically publish new versions of Content Views if it detects changes to the contained repositories. Please note that the detection is only checking that the repository was synced after the last publish of the Content View, no verification is done whether the sync actually contained new packages.
+`cvmanager` can be configured to automatically publish new versions of Content Views if it detects changes to the contained repositories. Please note that the detection is only checking that the repository was synced after the last publish of the Content View, no verification is done whether the sync actually contained new packages. The option checkrepos will check the sync task and check if new packages were downloaded or not. If no new packages were downloaded, then the repository will not be marked for publish.
 
+To use this feature, configure the `checkrepos` flag in the configuration file and call `cvmanager publish`.
 To use this feature, configure the `publish` array in the configuration file and call `cvmanager publish`.
 
 
@@ -82,6 +83,7 @@ Example configuration for `cvmanager`:
 * `lifecycle`: target Lifecycle Environment ID (not name) for `promote`
 * `keep`: how many non-published versions of a Content View shall be kept when doing a `clean`
 * `wait`: should cvmanager wait for tasks to finish, or run them in the background
+* `checkrepos`: should cvmanager check that repo packages were actually downloaded before flagging for publish, or just publish if a sync executed
 
 
 ## Example Workflows

--- a/cvmanager
+++ b/cvmanager
@@ -33,6 +33,7 @@ require 'time'
   :force       => false,
   :wait        => false,
   :promote_cvs => false,
+  :checkrepos  => false,
 }
 
 @options = {
@@ -79,6 +80,9 @@ optparse = OptionParser.new do |opts|
   end
   opts.on("--wait", "wait for started tasks to finish") do
     @options[:wait] = true
+  end
+  opts.on("--checkrepos", "check repository content was changed before publish") do
+    @options[:checkrepos] = true
   end
 end
 optparse.parse!
@@ -276,6 +280,7 @@ end
 
 def publish()
   tasks = []
+  searchtasks = []
 
   cvs = []
   req = @api.resource(:content_views).call(:index, {:organization_id => @options[:org], :full_results => true})
@@ -305,7 +310,42 @@ def publish()
       end
       if repo_last_sync > cv_last_published
         puts " repo #{repo['label']} (id: #{repo['id']}) seems newer than CV #{cv['name']} (id: #{cv['id']}) (#{repo_last_sync} > #{cv_last_published}), lets publish"
-        needs_publish = true
+        if @options[:checkrepos]
+          sync_task = @api.resource(:foreman_tasks).call(:show, {:id => repo['last_sync']['id']})
+          if sync_task['humanized']['output'] == "No new packages."
+            puts "#{sync_task['humanized']['output']} Found in last sync task, will search for past sync tasks."
+            taskreq = @api.resource(:foreman_tasks).call(:index, {:search => 'label=Actions::Katello::Repository::Sync', :full_results => true}, :per_page => 100, :sort_by => :ended_at)
+            searchtasks.concat(taskreq['results'])
+            while (taskreq['results'].length == taskreq['per_page'].to_i)
+              taskreq = @api.resource(:foreman_tasks).call(:index, {:search => 'label=Actions::Katello::Repository::Sync', :full_results => true, :per_page => taskreq['per_page'], :sort_by => :ended_at, :page => taskreq['page'].to_i+1})
+              searchtasks.concat(taskreq['results'])
+            end
+            searchtasks.each do |tasker|
+              next if tasker['id'] == sync_task['id']
+              task_completed_at = Time.xmlschema(tasker['ended_at']) rescue Time.parse(tasker['ended_at'])
+              if task_completed_at >= cv_last_published
+                if tasker['input']['repository']['id'] == repo['id']
+                  puts "Found past task from #{task_completed_at} that matches repo id: #{tasker['input']['repository']['id']}"
+                  if tasker['humanized']['output'] == "No new packages."
+                    puts "#{tasker['humanized']['output']} This past task will NOT trigger a Publish."
+                  else
+                    puts "#{tasker['humanized']['output']} This past task will trigger a Publish."
+                    needs_publish = true
+                    break
+                  end
+                end
+              else
+                puts "No more past tasks found, Publish will be SKIPPED."
+                break
+              end
+            end
+          else
+            puts "#{sync_task['humanized']['output']} Will Publish."
+            needs_publish = true
+          end
+        else
+          needs_publish = true
+        end
       end
     end
     if not needs_publish and @options[:force]

--- a/cvmanager.yaml
+++ b/cvmanager.yaml
@@ -7,6 +7,7 @@
   :org: 1
   :lifecycle: 2
   :keep: 5
+  :checkrepos: true
 :cv:
   something: 1
 :ccv:


### PR DESCRIPTION
Check the last sync job to see if packages were downloaded or not. If no new packages were downloaded then do not select for publish.