### PR TITLE
Skip tasks if they didn't end in success.

### DIFF
--- a/cvmanager
+++ b/cvmanager
@@ -330,6 +330,7 @@ def publish()
             end
             searchtasks.each do |tasker|
               next if tasker['id'] == sync_task['id']
+              next if tasker['result'] != 'success'
               task_completed_at = Time.xmlschema(tasker['ended_at']) rescue Time.parse(tasker['ended_at'])
               if task_completed_at >= cv_last_published
                 if tasker['input']['repository']['id'] == repo['id']


### PR DESCRIPTION
If a job is pending (running) when the cvmanager is executed with checkrepos enabled, a previous sync task could have an end date as nil. This scenario will result in an exception trying to parse the ended_at to a time value. Figured it is best to only look at successful jobs.
