### PR TITLE
Fixing text over code behavior

### DIFF
--- a/cvmanager
+++ b/cvmanager
@@ -428,7 +428,6 @@ def publish()
     if needs_publish
       puts "Publishing #{cv['name']}"
       if not @options[:noop]
-        puts " Publishing #{cv['name']}"
         req = @api.resource(:content_views).call(:publish, {:id => cv['id'], :description => 'autopublish'})
         tasks << req['id']
         wait([req['id']]) if @options[:sequential]

--- a/cvmanager
+++ b/cvmanager
@@ -231,8 +231,8 @@ def update()
         desired_version = @yaml[:cv][component['content_view']['label']]
         puts_verbose "  Found new version #{desired_version} in CV part of the config"
       else
-        desired_version = component['version']
         puts_verbose "  Did not find a new version, keeping #{desired_version}"
+        next
       end
 
       # instead of hard-coding the versions, the user can also specify "latest"
@@ -428,6 +428,7 @@ def publish()
     if needs_publish
       puts "Publishing #{cv['name']}"
       if not @options[:noop]
+        puts " Publishing #{cv['name']}"
         req = @api.resource(:content_views).call(:publish, {:id => cv['id'], :description => 'autopublish'})
         tasks << req['id']
         wait([req['id']]) if @options[:sequential]

--- a/cvmanager
+++ b/cvmanager
@@ -226,12 +226,12 @@ def update()
       # never touch non-mentioned components
       if @yaml[:ccv].is_a?(Hash) and @yaml[:ccv].has_key?(ccv['label']) and @yaml[:ccv][ccv['label']].has_key?(component['content_view']['label'])
         desired_version = @yaml[:ccv][ccv['label']][component['content_view']['label']]
-        puts_verbose "  Found new version #{desired_version} in CCV part of the config"
+        puts_verbose "  Desired version #{desired_version} found in CCV"
       elsif @yaml[:cv].is_a?(Hash) and @yaml[:cv].has_key?(component['content_view']['label'])
         desired_version = @yaml[:cv][component['content_view']['label']]
-        puts_verbose "  Found new version #{desired_version} in CV part of the config"
+        puts_verbose "  Desired version #{desired_version} found in CV"
       else
-        puts_verbose "  Did not find a new version, keeping #{desired_version}"
+        puts_verbose "  Desired version not found, skipping"
         next
       end
 


### PR DESCRIPTION
Even if https://github.com/RedHatSatellite/katello-cvmanager/issues/30 is closed, the current code say that a new version is found, while this is just "desired version found".

Also, in case of match, in non verbose puts, the publish is reported.