### PR TITLE
Add the updating of puppet module versions within a CV

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,20 @@ After a new version of a Composite Content View is created it is only available 
 `cvmanager promote` will iterate over all listed Composite Content Views and check if their latest version is promoted to Development, if it isn't the promote is triggered.
 
 
+## Update puppet modules
+A Content View includes specific versions of the puppet modules it includes. These can be set to always update to the latest version or to a fixed specific version number for the module. 
+
+`cvmanager` can automatically update the modules to a specified version using `cvmanager puppet`
+
+    :puppet:
+      rhel7:
+        test-test1: 0.2.0
+        test-test2: 0.2.0
+        test-test3: 0.2.0
+
+This will publish the rhel7 Content View with the test-test1, test-test2, and test-test3 puppet modules all at version 0.2.0.  Any puppet modules in the cv not mention in the config will behave as they would for any other publish (i.e. modules set to "latest" will be updated).
+
+
 ## Configuration
 
 Example configuration for `cvmanager`:

--- a/cvmanager
+++ b/cvmanager
@@ -443,6 +443,72 @@ def publish()
   wait(tasks)
 end
 
+
+def puppet()
+  tasks = []
+  modules = {} 
+
+  ## get all the puppet modules currently in satellite
+  req = @api.resource(:puppet_modules).call(:index, {:organization_id => @options[:org], :full_results => true})
+  req['results'].each do |r|
+    modules[r['author'] + "-" + r['name'] +"-"+ r['version']]= r
+  end
+  while (req['results'].length == req['per_page'].to_i)
+    req = @api.resource(:puppet_modules).call(:index, {:organization_id => @options[:org], :full_results => true, :per_page => req['per_page'], :page => req['page'].to_i+1})
+    req['results'].each do |r|
+      modules[r['author'] + "-" + r['name'] +"-"+ r['version']]= r
+    end
+  end
+
+  ## for each cv in the config file
+  @yaml[:puppet].keys.each do |cv|
+     needs_publish = false
+     ## get the content view for its id, and its list of current puppet modules
+     contentview = @api.resource(:content_views).call(:index, {:organization_id => @options[:org],:search => "name=" +cv })
+     cvid = contentview['results'][0]['id']
+     current = {}
+     ## current modules in the CV
+     contentview['results'][0]['puppet_modules'].each do |m|
+       current[m['author']+"-"+m['name']]=m
+     end
+
+     ## for each puppet module in the cv in the config file compare if the uuid matches the version currently in the cv
+     @yaml[:puppet][cv].keys.each do |pmod|
+       modulename = pmod + "-" + @yaml[:puppet][cv][pmod]
+       if current.has_key?(pmod) and (current[pmod]['uuid'] != modules[modulename]['uuid'] )
+         needs_publish = true
+         
+         if not @options[:noop]
+           puts "updating #{cv} to #{modulename}"
+           req = @api.resource(:content_view_puppet_modules).call(:update, {:organization_id => @options[:org], :full_results => true, "content_view_id"=>cvid ,"id"=>current[pmod]['id'] ,"content_view_puppet_module"=>modules[modulename] })
+         else
+           puts " [noop] updating #{cv} to #{modulename}"
+         end  
+       else
+         puts "#{cv} already includes #{modulename}"
+       end
+     end
+     if needs_publish
+       tasks += publishCV(cvid,cv)
+     end
+  end 
+  wait(tasks)
+end
+
+
+def publishCV(id,name)
+  tasks = []
+  if not @options[:noop]
+    req = @api.resource(:content_views).call(:publish, {:id => id, :description => @options[:description]})
+    tasks << req['id']
+    wait([req['id']]) if @options[:sequential]
+  else
+    puts " [noop] #{name}"
+  end
+  tasks
+end
+
+
 def wait(tasks)
   if @options[:wait]
     need_wait = tasks
@@ -483,4 +549,6 @@ elsif action == 'promote'
   promote
 elsif action == 'publish'
   publish
+elsif action == 'puppet'
+  puppet
 end


### PR DESCRIPTION
Normally the puppet module versions in a CV are all set to update to the latest version on publish. If you dont do this then you have to set the version numbers for each module seperately in the gui which is a pain, error prone, and a task that cvmanager can do so much better.