### PR TITLE
Fix due to Katello Bug #23458

### DIFF
--- a/cvmanager
+++ b/cvmanager
@@ -182,10 +182,15 @@ def clean()
       else
         puts " removing #{version['version']}"
         if not @options[:noop]
-          req = @api.resource(:content_view_versions).call(:destroy, {:id => version['id']})
-          tasks << req['id']
-          if @options[:sequential] > 0 and tasks.length >= @options[:sequential]
-            tasks = wait(tasks)
+          begin
+            req = @api.resource(:content_view_versions).call(:destroy, {:id => version['id']})
+            tasks << req['id']
+            if @options[:sequential] > 0 and tasks.length >= @options[:sequential]
+              tasks = wait(tasks)
+            end
+          rescue
+            puts " Impossible to delete version \"#{version['id']}\""
+            puts " Probably it is locked by a Composite Content View"
           end
         else
           puts " [noop] would delete content view version with id #{version['id']}"


### PR DESCRIPTION
The information by content_view_versions API is not always true. So cvmanager could try to delete some locked Content View Version. If the Content View Version is locked the error answers with a 500 error and the script terminates.
The bug of katello is traced here: https://projects.theforeman.org/issues/23458