### PR TITLE
 Make Promote() use cv version which user defined in YAML, not just latest

### DIFF
--- a/cvmanager
+++ b/cvmanager
@@ -350,17 +350,40 @@ def promote()
 
     puts "Inspecting #{ccv['label']}"
 
-    latest_version = ccv['versions'].sort_by { |v| v['version'].to_f }.reverse[0]
-    next if ! latest_version
+    # get the desired version for this component from the YAML
+    # either the version for the component in this CCV is set
+    # or it is set globally
+    # never touch non-mentioned components
+    if @yaml[:cv].is_a?(Hash) and @yaml[:cv].has_key?(ccv['label'])
+      users_version = @yaml[:cv][ccv['label']]
+      puts_verbose "  Desired version #{users_version} found in CV"
 
-    if not latest_version['environment_ids'].include?(@options[:lifecycle])
-      puts " Promoting latest version to lifecycle-environment #{@options[:lifecycle]}"
-      if not @options[:noop]
-        req = @api.resource(:content_view_versions).call(:promote, {:id => latest_version['id'], :environment_id => @options[:lifecycle], :force => @options[:force]})
-        tasks << req['id']
-        wait([req['id']]) if @options[:sequential]
+      # instead of hard-coding the versions, the user can also specify "latest"
+      # figure out the latest content view version, choose it, unless there is none
+      if users_version == 'latest'
+        desired_version = ccv['versions'].sort_by { |v| v['version'].to_f }.reverse[0]
+        next if ! desired_version
       else
-        puts " [noop] Promoting #{latest_version['id']} to lifecycle-environment #{@options[:lifecycle]}"
+        desired_version = ccv['versions'].select {|v| v["version"].to_f == users_version }[0]
+        next if ! desired_version
+      end
+    else
+      puts_verbose "  Desired version not found, skipping"
+      next
+    end
+
+    if not desired_version['environment_ids'].include?(@options[:lifecycle])
+      puts " Promoting version #{desired_version['version']} to lifecycle-environment #{@options[:lifecycle]}"
+      if not @options[:noop]
+        begin
+          req = @api.resource(:content_view_versions).call(:promote, {:id => desired_version['id'], :environment_id => @options[:lifecycle], :force => @options[:force]})
+          tasks << req['id']
+          wait([req['id']]) if @options[:sequential]
+        rescue RestClient::ExceptionWithResponse => e # catch exceptions with more helpful error content
+          puts e.response
+        end
+      else
+        puts " [noop] Promoting #{desired_version['version']} to lifecycle-environment #{@options[:lifecycle]}"
       end
     end
   end


### PR DESCRIPTION
Pull request verbatim from the tested code [in issue #62.](https://github.com/RedHatSatellite/katello-cvmanager/issues/62) To reiterate:

I had a use case where we don't use composite content views, yet I wanted the `promote` command to use the content view version I defined. However, for some reason the `promote` command always uses the latest and does not check for the version the user defined in `:cv:` under YAML at all.

I suggest a solution in the code below, allowing the user specified version in YAML to be used, as well as latest. since I just hacked this together by combining aspects of the `update()` function, I will just paste the `promote()` function I made.

Also when the request in promote() gave a 400 bad request, as the exception was not handled, so I added a `rescue` statement, which now helpfully tells the command line user that they "Cannot promote environment out of sequence. Use force to bypass restriction.".

The YAML I use, where i have Library.yaml , dev.yaml (always kept up to date with Library), test.yaml, prod.yaml.

```
# prod.yaml
:settings:
  :user: admin
  :pass: YOURPASSWORD
  :uri: https://localhost
  :timeout: 300
  :org: 1              # always 1 
  :lifecycle: 6        # ID of the lifecycle, not always obvious
  :checkrepos: true    # check if the latest repo packages are already in the curre
nt content view
  :promote_cvs: true   # don't use composite content views for publishing
  :keep: 5
  :wait: false         # should cvmanager wait for tasks to finish, or run them in 
the background
  :sequential: 1       # run only one task at once
:cv:
  rhel7: 10.0   # I specifically want version 10 and not the latest 12
:publish:
  - rhel7
:promote:
  - rhel7
```