### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The following permissions are required to run `cvmanager`:
 | Content Views | view_content_views, publish_content_views, promote_or_remove_content_views, destroy_content_views|
 | Lifecycle Environment | promote_or_remove_content_views_to_environments|
 | Product and Repositories | view_products |
+| Satellite tasks/task | view_foreman_tasks |
 
 ## Example Workflows
 


### PR DESCRIPTION
Hi while configuring katello-cvmanager on Satellite 6.6 I noticed that I needed an extra permission for my dedicated user in order to be able to run the script. I added this extra role to the README.md.